### PR TITLE
Update info/1 directives for the preferred format for versions and dates in Logtalk 3.36.0

### DIFF
--- a/app_settings.lgt
+++ b/app_settings.lgt
@@ -66,9 +66,9 @@ app_prefix('WEBTALK_').
 :- object(app_settings).
 
     :- info([
-        version is 4.0,
+        version is 4:0:0,
         author is 'Sando George',
-        date is 2018/08/19,
+        date is 2018-08-19,
         comment is 'Base configuration object.'
     ]).
 
@@ -243,9 +243,9 @@ app_prefix('WEBTALK_').
     extends(app_settings)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/10/19,
+        date is 2017-10-19,
         comment is 'Development environment specific configuration object.'
     ]).
 
@@ -255,9 +255,9 @@ app_prefix('WEBTALK_').
     extends(app_settings)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/10/19,
+        date is 2017-10-19,
         comment is 'Testing environment specific configuration object.'
     ]).
 
@@ -267,9 +267,9 @@ app_prefix('WEBTALK_').
     extends(app_settings)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/10/19,
+        date is 2017-10-19,
         comment is 'Production environment specific configuration object.'
     ]).
 

--- a/core/blueprint/api/api.lgt
+++ b/core/blueprint/api/api.lgt
@@ -33,9 +33,9 @@ http:location(api, root('api'), []).
 :- object(api).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/10/19,
+        date is 2017-10-19,
         comment is 'Defines handlers for RESTful API endpoints.'
     ]).
 

--- a/core/blueprint/auth/auth.lgt
+++ b/core/blueprint/auth/auth.lgt
@@ -60,9 +60,9 @@ http:location(auth, root('auth'), []).
 :- object(auth).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/03,
+        date is 2017-11-03,
         comment is 'Defines handlers for authentication pages.'
     ]).
 

--- a/core/blueprint/config/config.lgt
+++ b/core/blueprint/config/config.lgt
@@ -60,9 +60,9 @@ http:location(config, root('config'), []).
 :- object(config).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/03,
+        date is 2017-11-03,
         comment is 'Defines handlers for authentication pages.'
     ]).
 

--- a/core/blueprint/install/install.lgt
+++ b/core/blueprint/install/install.lgt
@@ -31,9 +31,9 @@
 :- object(install).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/04,
+        date is 2017-11-04,
         comment is 'Defines handlers installation pages.'
     ]).
 

--- a/core/blueprint/main/main.lgt
+++ b/core/blueprint/main/main.lgt
@@ -30,9 +30,9 @@
 :- object(main).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/10/19,
+        date is 2017-10-19,
         comment is 'Defines handlers for HTML pages.'
     ]).
 

--- a/core/blueprint/static/static.lgt
+++ b/core/blueprint/static/static.lgt
@@ -35,9 +35,9 @@ http:location(static, root('static'), []).
 :- object(static).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/04,
+        date is 2017-11-04,
         comment is 'Defines handlers for static file requests.'
     ]).
 

--- a/core/blueprint/wellknown/wellknown.lgt
+++ b/core/blueprint/wellknown/wellknown.lgt
@@ -35,9 +35,9 @@ http:location(well_known, root('.well-known'), []).
 :- object(wellknown).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/04,
+        date is 2017-11-04,
         comment is 'Defines handlers for completing ACME challenges.'
     ]).
 

--- a/core/extension/menu/ext_menu.lgt
+++ b/core/extension/menu/ext_menu.lgt
@@ -23,9 +23,9 @@
     extends(extension)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/15,
+        date is 2017-11-15,
         comment is 'Menu extension predicates.'
     ]).
 

--- a/core/extension/permission/ext_permission.lgt
+++ b/core/extension/permission/ext_permission.lgt
@@ -24,9 +24,9 @@
     extends(extension)).
 
     :- info([
-        version is 1.1,
+        version is 1:1:0,
         author is 'Sando George',
-        date is 2018/12/24,
+        date is 2018-12-24,
         comment is 'Permission system predicates.'
     ]).
 

--- a/core/lib/blueprint/blueprint.lgt
+++ b/core/lib/blueprint/blueprint.lgt
@@ -23,9 +23,9 @@
 :- object(blueprint).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2018/08/12,
+        date is 2018-08-12,
         comment is 'Utility predicates for blueprint handling.'
     ]).
 

--- a/core/lib/extend/extend.lgt
+++ b/core/lib/extend/extend.lgt
@@ -20,9 +20,9 @@
 :- protocol(extend).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/14,
+        date is 2017-11-14,
         comment is 'Features common to both themes and extensions.'
     ]).
 

--- a/core/lib/extend/extension.lgt
+++ b/core/lib/extend/extension.lgt
@@ -21,9 +21,9 @@
     implements(extend)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/14,
+        date is 2017-11-14,
         comment is 'Base prototype for all extensions.'
     ]).
 

--- a/core/lib/extend/extension_manager.lgt
+++ b/core/lib/extend/extension_manager.lgt
@@ -24,9 +24,9 @@
 :- object(extension_manager).
 
     :- info([
-        version is 1.1,
+        version is 1:1:0,
         author is 'Sando George',
-        date is 2018/12/24,
+        date is 2018-12-24,
         comment is 'Predicates used for managing extensions.'
     ]).
 

--- a/core/lib/extend/theme.lgt
+++ b/core/lib/extend/theme.lgt
@@ -21,9 +21,9 @@
     implements(extend)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/14,
+        date is 2017-11-14,
         comment is 'Base prototype for all themes.'
     ]).
 

--- a/core/lib/extend/theme_manager.lgt
+++ b/core/lib/extend/theme_manager.lgt
@@ -23,9 +23,9 @@
 :- object(theme_manager).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/20,
+        date is 2017-11-20,
         comment is 'Predicates used for managing themes.'
     ]).
 

--- a/core/lib/form/field.lgt
+++ b/core/lib/form/field.lgt
@@ -25,9 +25,9 @@
     implements(formfield)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Base object for all fields.'
     ]).
 
@@ -94,9 +94,9 @@
     extends(field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Base input field.'
     ]).
 
@@ -134,9 +134,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Button input field.'
     ]).
 
@@ -148,9 +148,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Checkbox input field.'
     ]).
 
@@ -162,9 +162,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Color input field.'
     ]).
 
@@ -176,9 +176,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Date input field.'
     ]).
 
@@ -190,9 +190,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Datetime input field.'
     ]).
 
@@ -204,9 +204,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Email input field.'
     ]).
 
@@ -218,9 +218,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'File input field.'
     ]).
 
@@ -232,9 +232,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Hidden input field.'
     ]).
 
@@ -246,9 +246,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Image input field.'
     ]).
 
@@ -260,9 +260,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Month input field.'
     ]).
 
@@ -274,9 +274,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Number input field.'
     ]).
 
@@ -288,9 +288,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Password input field.'
     ]).
 
@@ -302,9 +302,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Radio input field.'
     ]).
 
@@ -316,9 +316,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Range input field.'
     ]).
 
@@ -330,9 +330,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Reset input field.'
     ]).
 
@@ -344,9 +344,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Search input field.'
     ]).
 
@@ -358,9 +358,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Submit input field.'
     ]).
 
@@ -372,9 +372,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Tel input field.'
     ]).
 
@@ -386,9 +386,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Text input field.'
     ]).
 
@@ -400,9 +400,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Time input field.'
     ]).
 
@@ -414,9 +414,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Url input field.'
     ]).
 
@@ -428,9 +428,9 @@
     extends(input_field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Week input field.'
     ]).
 
@@ -442,9 +442,9 @@
     extends(field)).
 
     :- info([
-        version is 1.1,
+        version is 1:1:0,
         author is 'Sando George',
-        date is 2018/12/24,
+        date is 2018-12-24,
         comment is 'Select field.'
     ]).
 
@@ -501,9 +501,9 @@
     extends(field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Submit field.'
     ]).
 
@@ -529,9 +529,9 @@
     extends(field)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/09,
+        date is 2017-11-09,
         comment is 'Textarea field.'
     ]).
 

--- a/core/lib/form/form.lgt
+++ b/core/lib/form/form.lgt
@@ -28,9 +28,9 @@
 :- object(form).
 
     :- info([
-        version is 1.1,
+        version is 1:1:0,
         author is 'Sando George',
-        date is 2017/12/24,
+        date is 2017-12-24,
         comment is 'Defines predicates for working with HTML forms.'
     ]).
 

--- a/core/lib/form/widget.lgt
+++ b/core/lib/form/widget.lgt
@@ -29,9 +29,9 @@
     implements(html_markup)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'Base HTML widget.'
     ]).
 
@@ -71,9 +71,9 @@
     extends(html_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <label> widget.'
     ]).
 
@@ -88,9 +88,9 @@
     extends(html_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input> widget.'
     ]).
 
@@ -107,9 +107,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="button"> widget.'
     ]).
 
@@ -121,9 +121,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="checkbox"> widget.'
     ]).
 
@@ -135,9 +135,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="color"> widget.'
     ]).
 
@@ -149,9 +149,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="date"> widget.'
     ]).
 
@@ -163,9 +163,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="date"> widget.'
     ]).
 
@@ -177,9 +177,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="email"> widget.'
     ]).
 
@@ -191,9 +191,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="file"> widget.'
     ]).
 
@@ -205,9 +205,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="hidden"> widget.'
     ]).
 
@@ -219,9 +219,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="image"> widget.'
     ]).
 
@@ -233,9 +233,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="month"> widget.'
     ]).
 
@@ -247,9 +247,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="number"> widget.'
     ]).
 
@@ -261,9 +261,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="password"> widget.'
     ]).
 
@@ -275,9 +275,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="radio"> widget.'
     ]).
 
@@ -289,9 +289,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="range"> widget.'
     ]).
 
@@ -303,9 +303,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="reset"> widget.'
     ]).
 
@@ -317,9 +317,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="search"> widget.'
     ]).
 
@@ -331,9 +331,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="submit"> widget.'
     ]).
 
@@ -345,9 +345,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="tel"> widget.'
     ]).
 
@@ -359,9 +359,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="text"> widget.'
     ]).
 
@@ -373,9 +373,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="time"> widget.'
     ]).
 
@@ -387,9 +387,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="url"> widget.'
     ]).
 
@@ -401,9 +401,9 @@
     extends(form_input_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <input type="week"> widget.'
     ]).
 
@@ -415,9 +415,9 @@
     extends(html_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <button> widget.'
     ]).
 
@@ -439,9 +439,9 @@
     extends(form_button_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <button type="submit"> widget.'
     ]).
 
@@ -453,9 +453,9 @@
     extends(html_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <option> widget.'
     ]).
 
@@ -473,9 +473,9 @@
     extends(html_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <select> widget.'
     ]).
 
@@ -493,9 +493,9 @@
     extends(html_widget)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/11,
+        date is 2017-11-11,
         comment is 'HTML <textarea> widget.'
     ]).
 

--- a/core/lib/routing/routing.lgt
+++ b/core/lib/routing/routing.lgt
@@ -34,9 +34,9 @@ http:request_expansion(RequestIn, RequestOut) :-
 :- object(routing).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/03,
+        date is 2017-11-03,
         comment is 'Defines common routing functions.'
     ]).
 

--- a/core/lib/templating/templating.lgt
+++ b/core/lib/templating/templating.lgt
@@ -33,9 +33,9 @@
 :- object(templating).
 
     :- info([
-        version is 1.3,
+        version is 1:3:0,
         author is 'Sando George',
-        date is 2018/12/24,
+        date is 2018-12-24,
         comment is 'Utility predicates for template handling.'
     ]).
 

--- a/core/model/model.lgt
+++ b/core/model/model.lgt
@@ -26,9 +26,9 @@
 :- object(model).
 
     :- info([
-        version is 1.1,
+        version is 1:1:0,
         author is 'Sando George',
-        date is 2018/12/24,
+        date is 2018-12-24,
         comment is 'Common object to access persistent models.'
     ]).
 

--- a/core/theme/base/theme_base.lgt
+++ b/core/theme/base/theme_base.lgt
@@ -21,9 +21,9 @@
     extends(theme)).
 
     :- info([
-        version is 1.0,
+        version is 1:0:0,
         author is 'Sando George',
-        date is 2017/11/14,
+        date is 2017-11-14,
         comment is 'Default theme predicates.'
     ]).
 

--- a/tests/config.lgt
+++ b/tests/config.lgt
@@ -21,9 +21,9 @@
     extends(lgtunit)).
 
     :- info([
-        version is 1.1,
+        version is 1:1:0,
         author is 'Sando George',
-        date is 2018/12/24,
+        date is 2018-12-24,
         comment is 'Test configuration object.'
     ]).
 

--- a/tests/model.lgt
+++ b/tests/model.lgt
@@ -21,9 +21,9 @@
     extends(lgtunit)).
 
     :- info([
-        version is 1.1,
+        version is 1:1:0,
         author is 'Sando George',
-        date is 2018/12/24,
+        date is 2018-12-24,
         comment is 'Test database model object.'
     ]).
 

--- a/tests/user_model.lgt
+++ b/tests/user_model.lgt
@@ -21,9 +21,9 @@
     extends(lgtunit)).
 
     :- info([
-        version is 1.1,
+        version is 1:1:0,
         author is 'Sando George',
-        date is 2018/12/24,
+        date is 2018-12-24,
         comment is 'Test database models for user objects.'
     ]).
 


### PR DESCRIPTION
Note that this PR makes Logtalk 3.36.0 or later the required version.