### PR TITLE
2 more "config"s to atom

### DIFF
--- a/core/theme/base/template/base.html
+++ b/core/theme/base/template/base.html
@@ -70,7 +70,7 @@
             <ul class="sidebar-nav">
                 <li class="sidebar-brand">
                     <span>
-                        <a href="{{ url_for("config") }}">Core</a>
+                        <a href="{{ url_for('config') }}">Core</a>
                     </span>
                 </li>
                 {% each menus.config_core.items, item %}
@@ -80,7 +80,7 @@
                 {% end %}
                 <li class="sidebar-brand">
                     <span>
-                        <a href="{{ url_for("config.vendor") }}">Vendor</a>
+                        <a href="{{ url_for('config.vendor') }}">Vendor</a>
                     </span>
                 </li>
                 {% each menus.config_vendor.items, item %}


### PR DESCRIPTION
when clicking on config after the installation process is complete, i was getting more errors related to the use of strings. Many were fixed by @PaulBrownMagic and in #17. 

i think these fixes are correct, though i still have a problem on clicking config.